### PR TITLE
correct stopping criterion

### DIFF
--- a/bisection.m
+++ b/bisection.m
@@ -164,7 +164,7 @@ end
         x = (ub+lb)/2;
         fx = f(x);
         outsideTolFun = abs(fx)  > tolFun;
-        outsideTolX = (ub - lb) > tolX;
+        outsideTolX = (x - lb) > tolX;
         stillNotDone = outsideTolX & outsideTolFun;
     end
 


### PR DESCRIPTION
You can verify this by running the Example 2 twice; once with precision of 1e-6 and once with 1e-10 The difference is too small by a factor 2, as you do one iteration too many.

```matlab
% Example 2b
[A, B] = meshgrid(linspace(1,2,6), linspace(4,12,10));
f = @(x) A.*x.^0.2 + B.*x.^0.87 - 15;
error = abs(bisection(f,0,5,0,1e-10) - bisection(f,0,5,0,1e-6));
disp(max(error(:)))% before: 2.9449e-07, after: 5.8142e-07
```